### PR TITLE
Removed is_plugin_active check

### DIFF
--- a/ucf-weather.php
+++ b/ucf-weather.php
@@ -44,7 +44,7 @@ if ( ! function_exists( 'ucf_weather_init' ) ) {
 	/**
 	 * Called when all plugins are loaded.
 	 * Add all actions and hooks here.
-	 * 
+	 *
 	 * @author Jim Barnes
 	 * @since 1.0.0
 	 **/
@@ -58,10 +58,6 @@ if ( ! function_exists( 'ucf_weather_init' ) ) {
 		add_action( 'init', array( 'UCF_Weather_Shortcode', 'register_shortcode' ) );
 		// Add frontend assets
 		add_action( 'wp_enqueue_scripts', array( 'UCF_Weather_Config', 'enqueue_frontend_assets' ), 10, 0 );
-		// If `WP-Shortcode-Interface` plugin is installed, register interface.
-		if ( is_plugin_active( 'WP-Shortcode-Interface/wp-shortcode-interface.php' ) ) {
-			//add_action( 'wp_scif_add_shortcode', array( 'UCF_Weather_Shortcode', 'register_shortcode_interface' ), 10, 1 );
-		}
 	}
 
 	add_action( 'plugins_loaded', 'ucf_weather_init' );


### PR DESCRIPTION
Fixes the same issue as: https://github.com/UCF/UCF-Events-Plugin/pull/25

I've removed the entire if-statement for now since we don't have a WP SCIF registration hook written yet for this plugin.