### PR TITLE
Added the ucf-weather block

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Provides a shortcode for displaying weather from the UCF weather service.
 Enhancements:
 * Added composer file.
 
-### 1.1.1. ###
+### 1.1.1 ###
 Bug Fixes:
 * Remove id attribute from the weather SVGs in https://github.com/UCF/UCF-Weather-Shortcode/pull/25
 * Update packages & fix eslint errors in https://github.com/UCF/UCF-Weather-Shortcode/pull/24

--- a/includes/ucf-weather-block.php
+++ b/includes/ucf-weather-block.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Handles registering and rendering the weather block.
+ * Reuses the same backend code as the shortcode.
+ **/
+if ( ! class_exists( 'UCF_Weather_Block' ) ) {
+	class UCF_Weather_Block {
+		/**
+		 * Registers the block type and its editor assets.
+		 * @author Jim Barnes
+		 * @since 1.1.2
+		 **/
+		public static function register_block() {
+			// Bail if the block editor isn't available.
+			if ( ! function_exists( 'register_block_type' ) ) {
+				return;
+			}
+
+			wp_register_script(
+				'ucf-weather-block',
+				UCF_WEATHER__SCRIPT_URL . '/ucf-weather-block.js',
+				array( 'wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-server-side-render', 'wp-i18n' ),
+				false,
+				true
+			);
+
+			register_block_type( 'ucf/weather', array(
+				'editor_script'   => 'ucf-weather-block',
+				'attributes'      => array(
+					'feed'   => array(
+						'type'    => 'string',
+						'default' => 'default',
+					),
+					'layout' => array(
+						'type'    => 'string',
+						'default' => 'default',
+					),
+					'theme'  => array(
+						'type'    => 'string',
+						'default' => 'default',
+					),
+				),
+				'render_callback' => array( 'UCF_Weather_Block', 'callback' ),
+			) );
+		}
+
+		/**
+		 * Renders the block. Mirrors the shortcode callback so both
+		 * share the same backend rendering logic.
+		 * @author Jim Barnes
+		 * @since 1.1.2
+		 *
+		 * @param $atts Array | Block attributes
+		 * @return string | The markup to be displayed.
+		 **/
+		public static function callback( $atts ) {
+			$atts = wp_parse_args( $atts, array(
+				'feed'   => 'default',
+				'layout' => 'default',
+				'theme'  => 'default',
+			) );
+
+			return UCF_Weather_Common::display_weather( $atts );
+		}
+	}
+}
+?>

--- a/includes/ucf-weather-block.php
+++ b/includes/ucf-weather-block.php
@@ -16,11 +16,17 @@ if ( ! class_exists( 'UCF_Weather_Block' ) ) {
 				return;
 			}
 
+			if( ! function_exists('get_plugin_data') ){
+				require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+			}
+
+			$version = get_plugin_data( UCF_WEATHER__PLUGIN_FILE )['Version'];
+
 			wp_register_script(
 				'ucf-weather-block',
 				UCF_WEATHER__SCRIPT_URL . '/ucf-weather-block.js',
 				array( 'wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-server-side-render', 'wp-i18n' ),
-				false,
+				$version,
 				true
 			);
 

--- a/includes/ucf-weather-block.php
+++ b/includes/ucf-weather-block.php
@@ -54,11 +54,16 @@ if ( ! class_exists( 'UCF_Weather_Block' ) ) {
 		 * @return string | The markup to be displayed.
 		 **/
 		public static function callback( $atts ) {
-			$atts = wp_parse_args( $atts, array(
+			$atts = wp_parse_args( (array) $atts, array(
 				'feed'   => 'default',
 				'layout' => 'default',
 				'theme'  => 'default',
 			) );
+
+			// Sanitize/normalize block attributes before rendering.
+			$atts['feed']   = in_array( $atts['feed'], array( 'default', 'today', 'extended' ), true ) ? $atts['feed'] : 'default';
+			$atts['layout'] = sanitize_key( $atts['layout'] );
+			$atts['theme']  = sanitize_key( $atts['theme'] );
 
 			return UCF_Weather_Common::display_weather( $atts );
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "UCF-Weather-Shortcode",
       "devDependencies": {
         "@babel/cli": "^7.15.7",
         "@babel/core": "^7.15.8",
@@ -2963,14 +2962,24 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001313",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz",
-      "integrity": "sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -13240,9 +13249,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001313",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz",
-      "integrity": "sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true
     },
     "chalk": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "gulp-babel": "^8.0.0",
     "gulp-clean-css": "^4.3.0",
     "gulp-concat": "^2.6.1",
-    "gulp-eslint-new": "^0.4.0",
     "gulp-eslint-if-fixed": "^1.0.0",
+    "gulp-eslint-new": "^0.4.0",
     "gulp-include": "^2.4.1",
     "gulp-readme-to-markdown": "^0.2.1",
     "gulp-rename": "^2.0.0",
@@ -28,6 +28,5 @@
   },
   "browserslist": [
     "last 2 versions"
-  ],
-  "dependencies": {}
+  ]
 }

--- a/static/js/ucf-weather-block.js
+++ b/static/js/ucf-weather-block.js
@@ -78,7 +78,7 @@
 } )(
 	window.wp.blocks,
 	window.wp.element,
-	window.wp.blockEditor,
+	window.wp.blockEditor || window.wp.editor,
 	window.wp.components,
 	window.wp.serverSideRender,
 	window.wp.i18n

--- a/static/js/ucf-weather-block.js
+++ b/static/js/ucf-weather-block.js
@@ -1,0 +1,85 @@
+( function( blocks, element, blockEditor, components, serverSideRender, i18n ) {
+	var el = element.createElement;
+	var __ = i18n.__;
+	var InspectorControls = blockEditor.InspectorControls;
+	var PanelBody = components.PanelBody;
+	var SelectControl = components.SelectControl;
+	var ServerSideRender = serverSideRender;
+
+	blocks.registerBlockType( 'ucf/weather', {
+		title: __( 'UCF Weather', 'ucf-weather' ),
+		description: __( 'Displays the current weather using the UCF Weather service.', 'ucf-weather' ),
+		icon: 'cloud',
+		category: 'widgets',
+		attributes: {
+			feed: { type: 'string', default: 'default' },
+			layout: { type: 'string', default: 'default' },
+			theme: { type: 'string', default: 'default' }
+		},
+
+		edit: function( props ) {
+			var attributes = props.attributes;
+
+			return el(
+				element.Fragment,
+				null,
+				el(
+					InspectorControls,
+					null,
+					el(
+						PanelBody,
+						{ title: __( 'Weather Settings', 'ucf-weather' ), initialOpen: true },
+						el( SelectControl, {
+							label: __( 'Feed', 'ucf-weather' ),
+							value: attributes.feed,
+							options: [
+								{ label: __( 'Current (Default)', 'ucf-weather' ), value: 'default' },
+								{ label: __( 'Today', 'ucf-weather' ), value: 'today' },
+								{ label: __( 'Extended', 'ucf-weather' ), value: 'extended' }
+							],
+							onChange: function( value ) {
+								props.setAttributes( { feed: value } );
+							}
+						} ),
+						el( SelectControl, {
+							label: __( 'Theme', 'ucf-weather' ),
+							value: attributes.theme,
+							options: [
+								{ label: __( 'Default', 'ucf-weather' ), value: 'default' }
+							],
+							onChange: function( value ) {
+								props.setAttributes( { theme: value } );
+							}
+						} ),
+						el( SelectControl, {
+							label: __( 'Layout', 'ucf-weather' ),
+							value: attributes.layout,
+							options: [
+								{ label: __( 'Default', 'ucf-weather' ), value: 'default' }
+							],
+							onChange: function( value ) {
+								props.setAttributes( { layout: value } );
+							}
+						} )
+					)
+				),
+				el( ServerSideRender, {
+					block: 'ucf/weather',
+					attributes: attributes
+				} )
+			);
+		},
+
+		// Server-rendered block; no markup is saved to post content.
+		save: function() {
+			return null;
+		}
+	} );
+} )(
+	window.wp.blocks,
+	window.wp.element,
+	window.wp.blockEditor,
+	window.wp.components,
+	window.wp.serverSideRender,
+	window.wp.i18n
+);

--- a/ucf-weather.php
+++ b/ucf-weather.php
@@ -23,6 +23,7 @@ define( 'UCF_WEATHER__IMAGES_DIR', UCF_WEATHER__STATIC_DIR . 'img/' );
 include_once UCF_WEATHER__PLUGIN_DIR . 'includes/ucf-weather-config.php';
 include_once UCF_WEATHER__PLUGIN_DIR . 'includes/ucf-weather-feed.php';
 include_once UCF_WEATHER__PLUGIN_DIR . 'includes/ucf-weather-shortcode.php';
+include_once UCF_WEATHER__PLUGIN_DIR . 'includes/ucf-weather-block.php';
 include_once UCF_WEATHER__PLUGIN_DIR . 'includes/ucf-weather-common.php';
 include_once UCF_WEATHER__PLUGIN_DIR . 'admin/ucf-weather-admin.php';
 
@@ -58,6 +59,8 @@ if ( ! function_exists( 'ucf_weather_init' ) ) {
 
 		// Register the shortcode
 		add_action( 'init', array( 'UCF_Weather_Shortcode', 'register_shortcode' ) );
+		// Register the block
+		add_action( 'init', array( 'UCF_Weather_Block', 'register_block' ) );
 		// Add frontend assets
 		add_action( 'wp_enqueue_scripts', array( 'UCF_Weather_Config', 'enqueue_frontend_assets' ), 10, 0 );
 	}


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Weather-Shortcode.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Weather-Shortcode/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
- Adds the ucf/weather block. This block will display weather data from weather.cm.ucf.edu.
- Comes with 3 feed options, and a default layout. It is expected that additional layouts be registered within theme files.

**Motivation and Context**
This allows weather to be added to block editor pages without having to use the shortcode. The logic that renders the block is exactly the same as the shortcode.

**How Has This Been Tested?**
<img width="1174" height="132" alt="Screenshot 2026-06-23 at 2 34 35 PM" src="https://github.com/user-attachments/assets/b80cb7ba-2acf-4412-bbe5-736f1cecde4d" />

Screenshot of the widget being used on UCF Today using the today_nav layout that's specified in that theme.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
